### PR TITLE
Uncaught exception in nodered

### DIFF
--- a/node-red-watchdirectory.js
+++ b/node-red-watchdirectory.js
@@ -66,7 +66,7 @@ module.exports = function(RED) {
       }, 10000)
     }).on('error', (err) => {
       node.status({fill:"red", shape: "dot", text: "Error : "+err.message})
-      throw(err)
+      node.error(err)
     })
 
     //on close


### PR DESCRIPTION
On watcher.on use of throw cause uncaught exception in nodered, the right thing to do is call node.error instead.